### PR TITLE
Add Spanish translation

### DIFF
--- a/feathernotes/data/translations/feathernotes_es.ts
+++ b/feathernotes/data/translations/feathernotes_es.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../../about.ui" line="115"/>
         <source>License</source>
-        <translation></translation>
+        <translation>Licencia</translation>
     </message>
 </context>
 <context>
@@ -16,1026 +16,1027 @@
         <location filename="../../fn.cpp" line="1016"/>
         <location filename="../../fn.cpp" line="4833"/>
         <source>FeatherNotes</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="63"/>
         <source>Next (F3)</source>
-        <translation></translation>
+        <translation>Siguiente (F3)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="66"/>
         <source>F3</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="76"/>
         <source>Previous (F4)</source>
-        <translation></translation>
+        <translation>Anterior (F4)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="79"/>
         <source>F4</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="95"/>
         <source>Search...</source>
-        <translation></translation>
+        <translation>Buscar...</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="107"/>
         <source>Search only in names (Ctrl+Shift+F7)</source>
-        <translation></translation>
+        <translation>Buscar solo en nombres (Ctrl+Mayús+F7)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="110"/>
         <source>Ctrl+Shift+F7</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+F7</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="117"/>
         <source>Search only in tags (Shift+F7)</source>
-        <translation></translation>
+        <translation>Buscar solo en etiquetas (Mayús+F7)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="120"/>
         <source>Shift+F7</source>
-        <translation></translation>
+        <translation>Mayús+F7</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="130"/>
         <source>Search in all nodes (F7)</source>
-        <translation></translation>
+        <translation>Buscar en todos los nodos (F7)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="133"/>
         <source>F7</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="166"/>
         <source>Whole Word (F6)</source>
-        <translation></translation>
+        <translation>Palabras completas (F6)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="169"/>
         <source>Whole Word</source>
-        <translation></translation>
+        <translation>Palabras completas</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="172"/>
         <source>F6</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="150"/>
         <source>Match Case (F5)</source>
-        <translation></translation>
+        <translation>Distinguir mayúsculas de minúsculas (F5)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="153"/>
         <source>Match Case</source>
-        <translation></translation>
+        <translation>Distinguir mayúsculas de minúsculas</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="156"/>
         <source>F5</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="199"/>
         <source>&amp;File</source>
-        <translation></translation>
+        <translation>&amp;Archivo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="218"/>
         <source>&amp;Edit</source>
-        <translation></translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="233"/>
         <source>For&amp;mat</source>
-        <translation></translation>
+        <translation>&amp;Formato</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="265"/>
         <source>&amp;Tree</source>
-        <translation></translation>
+        <translation>Á&amp;rbol</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="288"/>
         <source>&amp;Options</source>
-        <translation></translation>
+        <translation>&amp;Opciones</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="300"/>
         <source>&amp;Search</source>
-        <translation></translation>
+        <translation>&amp;Buscar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="307"/>
         <location filename="../../fn.ui" line="952"/>
         <source>&amp;Help</source>
-        <translation></translation>
+        <translation>A&amp;yuda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="410"/>
         <source>Find:</source>
-        <translation></translation>
+        <translation>Buscar:</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="417"/>
         <source>Replace with:</source>
-        <translation></translation>
+        <translation>Sustituir con:</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="430"/>
         <source>To be replaced</source>
-        <translation></translation>
+        <translation>A sustituir</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="443"/>
         <source>Replacing text</source>
-        <translation></translation>
+        <translation>Texto de sustitución</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="450"/>
         <source>Previous (F9)</source>
-        <translation></translation>
+        <translation>Anterior (F9)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="453"/>
         <source>F9</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="463"/>
         <source>Next (F8)</source>
-        <translation></translation>
+        <translation>Siguiente (F8)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="466"/>
         <source>F8</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="476"/>
         <source>Replace all (F10)</source>
-        <translation></translation>
+        <translation>Sustituir todo (F10)</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="479"/>
         <source>F10</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="496"/>
         <source>&amp;Save</source>
-        <translation></translation>
+        <translation>&amp;Guardar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="499"/>
         <location filename="../../fn.cpp" line="734"/>
         <source>Save</source>
-        <translation></translation>
+        <translation>Guardar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="502"/>
         <source>Ctrl+S</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="507"/>
         <location filename="../../fn.cpp" line="490"/>
         <source>&amp;Open</source>
-        <translation></translation>
+        <translation>&amp;Abrir</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="510"/>
         <source>Open a file</source>
-        <translation></translation>
+        <translation>Abrir un archivo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="513"/>
         <source>Ctrl+O</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="521"/>
         <source>&amp;Undo</source>
-        <translation></translation>
+        <translation>&amp;Deshacer</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="524"/>
         <source>Undo</source>
-        <translation></translation>
+        <translation>Deshacer</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="527"/>
         <source>Ctrl+Z</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="535"/>
         <source>&amp;Redo</source>
-        <translation></translation>
+        <translation>&amp;Rehacer</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="538"/>
         <source>Redo</source>
-        <translation></translation>
+        <translation>Rehacer</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="541"/>
         <source>Ctrl+Shift+Z</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+Z</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="549"/>
         <source>&amp;Find</source>
-        <translation></translation>
+        <translation>&amp;Buscar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="552"/>
         <source>Show/hide searchbar</source>
-        <translation></translation>
+        <translation>Mostrar/Ocultar la barra de búsqueda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="555"/>
         <source>Ctrl+F</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="563"/>
         <source>&amp;Clear All Formats</source>
-        <translation></translation>
+        <translation>&amp;Limpiar todo el formato</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="566"/>
         <source>Clear all formats</source>
-        <translation></translation>
+        <translation>Limpiar todo el formato</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="569"/>
         <source>Ctrl+E</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="580"/>
         <source>&amp;Bold</source>
-        <translation></translation>
+        <translation>&amp;Negrita</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="583"/>
         <source>Bold</source>
-        <translation></translation>
+        <translation>Negrita</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="586"/>
         <source>Ctrl+B</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="597"/>
         <source>&amp;Italic</source>
-        <translation></translation>
+        <translation>&amp;Cursiva</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="600"/>
         <source>Italic</source>
-        <translation></translation>
+        <translation>Cursiva</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="603"/>
         <source>Ctrl+I</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="614"/>
         <source>&amp;Underline</source>
-        <translation></translation>
+        <translation>&amp;Subrayado</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="617"/>
         <source>Underline</source>
-        <translation></translation>
+        <translation>Subrayado</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="620"/>
         <source>Ctrl+U</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="631"/>
         <source>&amp;Strike Through</source>
-        <translation></translation>
+        <translation>&amp;Tachado</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="634"/>
         <source>Strike through</source>
-        <translation></translation>
+        <translation>Tachado</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="637"/>
         <source>Ctrl+T</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="645"/>
         <source>Te&amp;xt Color</source>
-        <translation></translation>
+        <translation>Color del te&amp;xto</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="648"/>
         <source>Text color</source>
-        <translation></translation>
+        <translation>Color del texto</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="651"/>
         <source>Alt+Shift+T</source>
-        <translation></translation>
+        <translation>Alt+Mayús+T</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="659"/>
         <source>Back&amp;ground Color</source>
-        <translation></translation>
+        <translation>Color de &amp;fondo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="662"/>
         <source>Background color</source>
-        <translation></translation>
+        <translation>Color de fondo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="665"/>
         <source>Alt+Shift+B</source>
-        <translation></translation>
+        <translation>Alt+Mayús+B</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="670"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>Opciones</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="675"/>
         <location filename="../../fn.cpp" line="489"/>
         <source>&amp;New Note</source>
-        <translation></translation>
+        <translation>&amp;Nueva nota</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="678"/>
         <source>Ctrl+Alt+Shift+N</source>
-        <translation></translation>
+        <translation>Ctrl+Alt+Mayús+N</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="686"/>
         <source>Save &amp;As</source>
-        <translation></translation>
+        <translation>Guardar &amp;como</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="689"/>
         <source>Ctrl+Shift+S</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+S</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="697"/>
         <source>&amp;Print</source>
-        <translation></translation>
+        <translation>&amp;Imprimir</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="700"/>
         <source>Ctrl+P</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="708"/>
         <source>P&amp;rint with Sub-Nodes</source>
-        <translation></translation>
+        <translation>Imprimir con &amp;subnodos</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="716"/>
         <source>Set Pass&amp;word</source>
-        <translation></translation>
+        <translation>&amp;Establecer la contraseña</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="721"/>
         <location filename="../../fn.cpp" line="492"/>
         <source>&amp;Quit</source>
-        <translation></translation>
+        <translation>&amp;Salir</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="724"/>
         <source>Ctrl+Q</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="732"/>
         <source>&amp;Cut</source>
-        <translation></translation>
+        <translation>&amp;Cortar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="735"/>
         <source>Ctrl+X</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="743"/>
         <source>C&amp;opy</source>
-        <translation></translation>
+        <translation>C&amp;opiar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="746"/>
         <source>Ctrl+C</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="754"/>
         <source>&amp;Paste</source>
-        <translation></translation>
+        <translation>&amp;Pegar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="757"/>
         <source>Ctrl+V</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="765"/>
         <source>&amp;Delete</source>
-        <translation></translation>
+        <translation>&amp;Borrar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="773"/>
         <source>&amp;Select All</source>
-        <translation></translation>
+        <translation>&amp;Seleccionar todo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="776"/>
         <source>Ctrl+A</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="784"/>
         <source>E&amp;mbed Image</source>
-        <translation></translation>
+        <translation>Insertar una i&amp;magen</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="787"/>
         <location filename="../../fn.cpp" line="3111"/>
         <source>Embed Image</source>
-        <translation></translation>
+        <translation>Insertar imagen</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="790"/>
         <source>Ctrl+Alt+Shift+I</source>
-        <translation></translation>
+        <translation>Ctrl+Alt+Mayús+I</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="798"/>
         <source>E&amp;xpand All</source>
-        <translation></translation>
+        <translation>E&amp;xpandir todo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="801"/>
         <source>Ctrl+Shift+Down</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+Abajo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="809"/>
         <source>Collap&amp;se All</source>
-        <translation></translation>
+        <translation>&amp;Contraer todo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="812"/>
         <source>Ctrl+Shift+Up</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+Arriba</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="820"/>
         <source>&amp;Append Sibling</source>
-        <translation></translation>
+        <translation>&amp;Añadir un hermano</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="823"/>
         <source>Ctrl+N</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="831"/>
         <source>Append &amp;Child</source>
-        <translation></translation>
+        <translation>Añadir un &amp;hijo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="834"/>
         <source>Ctrl+Shift+N</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+N</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="842"/>
         <source>&amp;Delete Node</source>
-        <translation></translation>
+        <translation>Borrar el &amp;nodo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="845"/>
         <source>Ctrl+D</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="853"/>
         <source>Move &amp;Up</source>
-        <translation></translation>
+        <translation>&amp;Subir</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="856"/>
         <source>Alt+Up</source>
-        <translation></translation>
+        <translation>Alt+Arriba</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="864"/>
         <source>Move Do&amp;wn</source>
-        <translation></translation>
+        <translation>&amp;Bajar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="867"/>
         <source>Alt+Down</source>
-        <translation></translation>
+        <translation>Alt+Abajo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="875"/>
         <source>Re&amp;name Node</source>
-        <translation></translation>
+        <translation>&amp;Renombrar el nodo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="878"/>
         <source>Ctrl+Shift+R</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+R</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="883"/>
         <source>Tree Pr&amp;operties</source>
-        <translation></translation>
+        <translation>Pr&amp;opiedades del árbol</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="886"/>
         <source>Ctrl+Shift+D</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+D</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="894"/>
         <source>Document &amp;Font</source>
-        <translation></translation>
+        <translation>Fuente del &amp;documento</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="908"/>
         <source>&amp;Wrap Lines</source>
-        <translation></translation>
+        <translation>&amp;Dividir las líneas</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="911"/>
         <source>Ctrl+W</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="925"/>
         <source>&amp;Auto-Indentation</source>
-        <translation></translation>
+        <translation>Sangría &amp;automática</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="928"/>
         <source>Ctrl+Shift+I</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+I</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="933"/>
         <source>&amp;Preferences</source>
-        <translation></translation>
+        <translation>&amp;Preferencias</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="936"/>
         <source>Ctrl+Shift+P</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+P</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="944"/>
         <source>Find and &amp;Replace</source>
-        <translation></translation>
+        <translation>Busca&amp;r y sustituir</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="947"/>
         <source>Ctrl+R</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="955"/>
         <source>Ctrl+H</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="960"/>
         <source>&amp;About</source>
-        <translation></translation>
+        <translation>&amp;Acerca de</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="968"/>
         <source>Pr&amp;int All Nodes</source>
-        <translation></translation>
+        <translation>Imprimir todos los &amp;nodos</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="979"/>
         <source>Superscrip&amp;t</source>
-        <translation></translation>
+        <translation>Su&amp;períndice</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="982"/>
         <source>Superscript</source>
-        <translation></translation>
+        <translation>Superíndice</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="985"/>
         <source>Alt+Shift+U</source>
-        <translation></translation>
+        <translation>Alt+Mayús+U</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="996"/>
         <source>Subscri&amp;pt</source>
-        <translation></translation>
+        <translation>Su&amp;bíndice</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="999"/>
         <source>Subscript</source>
-        <translation></translation>
+        <translation>Subíndice</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1002"/>
         <source>Alt+Shift+S</source>
-        <translation></translation>
+        <translation>Alt+Mayús+S</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1013"/>
         <source>C&amp;enter</source>
-        <translation></translation>
+        <translation>C&amp;entrado</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1016"/>
         <source>Align center</source>
-        <translation></translation>
+        <translation>Alinear al centro</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1019"/>
         <source>Alt+Shift+Down</source>
-        <translation></translation>
+        <translation>Alt+Mayús+Abajo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1030"/>
         <source>&amp;Right</source>
-        <translation></translation>
+        <translation>&amp;Derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1033"/>
         <source>Align right</source>
-        <translation></translation>
+        <translation>Alinear a la derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1036"/>
         <source>Alt+Shift+Right</source>
-        <translation></translation>
+        <translation>Alt+Mayús+Derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1047"/>
         <source>&amp;Left</source>
-        <translation></translation>
+        <translation>&amp;Izquierda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1050"/>
         <source>Align left</source>
-        <translation></translation>
+        <translation>Alinear a la izquierda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1053"/>
         <source>Alt+Shift+Left</source>
-        <translation></translation>
+        <translation>Alt+Mayús+Izquierda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1064"/>
         <source>&amp;Justify</source>
-        <translation></translation>
+        <translation>&amp;Justificado</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1067"/>
         <source>Justify</source>
-        <translation></translation>
+        <translation>Justificar</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1070"/>
         <source>Alt+Shift+Up</source>
-        <translation></translation>
+        <translation>Alt+Mayús+Arriba</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1078"/>
         <source>&amp;Prepend Sibling</source>
-        <translation></translation>
+        <translation>&amp;Preañadir un hermano</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1081"/>
         <source>Ctrl+M</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1089"/>
         <source>Move &amp;Left</source>
-        <translation></translation>
+        <translation>Mover a la &amp;izquierda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1092"/>
         <source>Alt+Left</source>
-        <translation></translation>
+        <translation>Alt+Izquierda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1100"/>
         <source>Move &amp;Right</source>
-        <translation></translation>
+        <translation>Mover a la &amp;derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1103"/>
         <source>Alt+Right</source>
-        <translation></translation>
+        <translation>Alt+Derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1111"/>
         <source>h&amp;2</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1114"/>
         <source>Header 2</source>
-        <translation></translation>
+        <translation>Encabezado 2</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1117"/>
         <source>Ctrl+2</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1125"/>
         <source>h&amp;1</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1128"/>
         <source>Header 1</source>
-        <translation></translation>
+        <translation>Encabezado 1</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1131"/>
         <source>Ctrl+1</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1139"/>
         <source>h&amp;3</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1142"/>
         <source>Header 3</source>
-        <translation></translation>
+        <translation>Encabezado 3</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1145"/>
         <source>Ctrl+3</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1153"/>
         <source>&amp;Node Font</source>
-        <translation></translation>
+        <translation>Fuente del &amp;nodo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1156"/>
         <source>Node Font</source>
-        <translation></translation>
+        <translation>Fuente del nodo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1161"/>
         <source>Scale I&amp;mage(s)</source>
-        <translation></translation>
+        <translation>Escalar las i&amp;mágenes</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1169"/>
         <source>Paste &amp;HTML</source>
-        <translation></translation>
+        <translation>Pegar &amp;HTML</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1172"/>
         <source>Ctrl+Shift+V</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+V</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1180"/>
         <source>&amp;Tags</source>
-        <translation></translation>
+        <translation>E&amp;tiquetas</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1183"/>
         <source>Ctrl+Shift+T</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+T</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1191"/>
         <source>Insert Lin&amp;k</source>
-        <translation></translation>
+        <translation>Insertar &amp;un enlace</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1194"/>
         <source>Ctrl+L</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1199"/>
         <source>C&amp;opy Link</source>
-        <translation></translation>
+        <translation>C&amp;opiar enlace</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1207"/>
         <source>I&amp;nsert Table</source>
-        <translation></translation>
+        <translation>I&amp;nsertar una tabla</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1210"/>
         <source>Ctrl+Alt+Shift+T</source>
-        <translation></translation>
+        <translation>Ctrl+Alt+Mayús+T</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1215"/>
         <source>Append Row</source>
-        <translation></translation>
+        <translation>Añadir una fila</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1220"/>
         <source>Delete Row</source>
-        <translation></translation>
+        <translation>Borrar la fila</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1225"/>
         <source>Append Column</source>
-        <translation></translation>
+        <translation>Añadir una columna</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1230"/>
         <source>Delete Column</source>
-        <translation></translation>
+        <translation>Borrar la columna</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1235"/>
         <source>Merge Cells</source>
-        <translation></translation>
+        <translation>Fusionar las celdas</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1240"/>
         <source>Prepend Row</source>
-        <translation></translation>
+        <translation>Preañadir una fila</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1245"/>
         <source>Prepend Column</source>
-        <translation></translation>
+        <translation>Preañadir una columna</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1253"/>
         <source>Export &amp;HTML</source>
-        <translation></translation>
+        <translation>Exportar a &amp;HTML</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1258"/>
         <source>Save Ima&amp;ge(s)</source>
-        <translation></translation>
+        <translation>Guardar imá&amp;genes</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1269"/>
         <source>RTL</source>
-        <translation></translation>
+        <translation>De derecha a izquierda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1272"/>
         <source>Ctrl+Alt+Shift+Left</source>
-        <translation></translation>
+        <translation>Ctrl+Alt+Mayús+Izquieda</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1283"/>
         <source>LTR</source>
-        <translation></translation>
+        <translation>De izquierda a derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1286"/>
         <source>Ctrl+Alt+Shift+Right</source>
-        <translation></translation>
+        <translation>Ctrl+Alt+Mayús+Derecha</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1291"/>
         <location filename="../../fn.ui" line="1294"/>
         <source>Menu</source>
-        <translation></translation>
+        <translation>Menú</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1302"/>
         <source>Node &amp;Icon</source>
-        <translation></translation>
+        <translation>&amp;Icono del nodo</translation>
     </message>
     <message>
         <location filename="../../fn.ui" line="1305"/>
         <source>Ctrl+Shift+C</source>
-        <translation></translation>
+        <translation>Ctrl+Mayús+C</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2031"/>
         <source>Node Icon</source>
-        <translation></translation>
+        <translation>Icono del nodo</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="272"/>
         <source>F11</source>
         <comment>Fullscreen</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="275"/>
         <source>Ctrl+Shift+W</source>
         <comment>Default size</comment>
-        <translation></translation>
+        <translation>Ctrl+Mayús+W</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="278"/>
         <source>Ctrl+=</source>
         <comment>Zoom in</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="279"/>
         <source>Ctrl++</source>
         <comment>Zoom in</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="280"/>
         <source>Ctrl+-</source>
         <comment>Zoom out</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="281"/>
         <source>Ctrl+0</source>
         <comment>Unzoom</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="484"/>
         <location filename="../../fn.cpp" line="4185"/>
         <source>&amp;Raise/Hide</source>
-        <translation></translation>
+        <translation>&amp;Elevar/Ocultar</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="649"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;big&gt;New note?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;b&gt;&lt;big&gt;¿Quiere crear una nueva nota?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="650"/>
         <source>&lt;center&gt;&lt;i&gt;Do you really want to leave this document&lt;/i&gt;&lt;/center&gt;
 &lt;center&gt;&lt;i&gt;and create an empty one?&lt;/i&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;i&gt;¿Seguro que quiere dejar el documento&lt;/i&gt;&lt;/center&gt;
+&lt;center&gt;&lt;i&gt;y crear uno vacío?&lt;/i&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="653"/>
         <location filename="../../fn.cpp" line="1866"/>
         <location filename="../../fn.cpp" line="3441"/>
         <source>Yes</source>
-        <translation></translation>
+        <translation>Sí</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="654"/>
         <location filename="../../fn.cpp" line="1867"/>
         <location filename="../../fn.cpp" line="3442"/>
         <source>No</source>
-        <translation></translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="726"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;big&gt;Save changes?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;b&gt;&lt;big&gt;¿Quiere guardar los cambios?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="728"/>
         <source>&lt;center&gt;&lt;i&gt;The document has been modified.&lt;/i&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;i&gt;El documendo ha sido modificado.&lt;/i&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="730"/>
         <source>&lt;center&gt;&lt;i&gt;The document has been removed.&lt;/i&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;i&gt;El documento ha sido borrado.&lt;/i&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="735"/>
         <source>Discard changes</source>
-        <translation></translation>
+        <translation>Descartar los cambios</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="736"/>
@@ -1049,25 +1050,25 @@
         <location filename="../../fn.cpp" line="4962"/>
         <location filename="../../fn.cpp" line="5078"/>
         <source>Cancel</source>
-        <translation></translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="988"/>
         <source>Open file...</source>
-        <translation></translation>
+        <translation>Abrir archivo...</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="990"/>
         <location filename="../../fn.cpp" line="1110"/>
         <location filename="../../fn.cpp" line="1131"/>
         <source>FeatherNotes documents (*.fnx)</source>
-        <translation></translation>
+        <translation>Documentos de FeatherNotes (*.fnx)</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1017"/>
         <location filename="../../fn.cpp" line="4834"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;big&gt;Cannot be saved!&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;b&gt;&lt;big&gt;¡No se puede guardar!&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1020"/>
@@ -1075,29 +1076,30 @@
         <location filename="../../fn.cpp" line="3919"/>
         <location filename="../../fn.cpp" line="4837"/>
         <source>Close</source>
-        <translation></translation>
+        <translation>Cerrar</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1108"/>
         <location filename="../../fn.cpp" line="1129"/>
         <source>Save As...</source>
-        <translation></translation>
+        <translation>Guardar como...</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1863"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;big&gt;Delete this node?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;b&gt;&lt;big&gt;¿Quiere borrar este nodo?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1864"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;i&gt;Warning!&lt;/i&gt;&lt;/b&gt;&lt;/center&gt;
 &lt;center&gt;This action cannot be undone.&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;b&gt;&lt;i&gt;¡Aviso!&lt;/i&gt;&lt;/b&gt;&lt;/center&gt;
+&lt;center&gt;Esta acción no se puede deshacer.&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1966"/>
         <source>Tags</source>
-        <translation></translation>
+        <translation>Etiquetas</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1979"/>
@@ -1110,96 +1112,96 @@
         <location filename="../../fn.cpp" line="4963"/>
         <location filename="../../fn.cpp" line="5079"/>
         <source>OK</source>
-        <translation></translation>
+        <translation>Aceptar</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2169"/>
         <location filename="../../fn.cpp" line="2202"/>
         <source>&lt;b&gt;Main nodes:&lt;/b&gt; &lt;i&gt;%1&lt;/i&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;All nodes:&lt;/b&gt; &lt;i&gt;%2&lt;/i&gt;</source>
-        <translation></translation>
+        <translation>&lt;b&gt;Nodos principales:&lt;/b&gt; &lt;i&gt;%1&lt;/i&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;Todos los nodos:&lt;/b&gt; &lt;i&gt;%2&lt;/i&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2175"/>
         <location filename="../../fn.cpp" line="2208"/>
         <source>&lt;b&gt;Note:&lt;/b&gt; &lt;i&gt;%1&lt;/i&gt;&lt;br&gt;&lt;b&gt;Main nodes:&lt;/b&gt; &lt;i&gt;%2&lt;/i&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;All nodes:&lt;/b&gt; &lt;i&gt;%3&lt;/i&gt;</source>
-        <translation></translation>
+        <translation>&lt;b&gt;Nota:&lt;/b&gt; &lt;i&gt;%1&lt;/i&gt;&lt;br&gt;&lt;b&gt;Nodos principales:&lt;/b&gt; &lt;i&gt;%2&lt;/i&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;Todos los nodos:&lt;/b&gt; &lt;i&gt;%3&lt;/i&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2479"/>
         <source>%1 Matches</source>
-        <translation></translation>
+        <translation>%1 coincidencias</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2481"/>
         <source>One Match</source>
-        <translation></translation>
+        <translation>Una coincidencia</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2483"/>
         <location filename="../../fn.cpp" line="2794"/>
         <source>No Match</source>
-        <translation></translation>
+        <translation>No hay coincidencias</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2598"/>
         <location filename="../../fn.cpp" line="2650"/>
         <source>Replacement</source>
-        <translation></translation>
+        <translation>Sustitución</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2893"/>
         <source>No Replacement</source>
-        <translation></translation>
+        <translation>No han habido sustituciones</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2895"/>
         <source>One Replacement</source>
-        <translation></translation>
+        <translation>Una sustitución</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2897"/>
         <source>%1 Replacements</source>
-        <translation></translation>
+        <translation>%1 sustituciones</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3041"/>
         <source>Insert Link</source>
-        <translation></translation>
+        <translation>Insertar un enlace</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2039"/>
         <location filename="../../fn.cpp" line="3120"/>
         <source>Image path</source>
-        <translation></translation>
+        <translation>Insertar ruta</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2043"/>
         <location filename="../../fn.cpp" line="3124"/>
         <source>Open image</source>
-        <translation></translation>
+        <translation>Abrir una imagen</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3132"/>
         <location filename="../../fn.cpp" line="3291"/>
         <source>Scaling percentage</source>
-        <translation></translation>
+        <translation>Porcentaje de escala</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2061"/>
         <location filename="../../fn.cpp" line="3239"/>
         <source>Open Image...</source>
-        <translation></translation>
+        <translation>Abrir imagen...</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="486"/>
         <location filename="../../fn.cpp" line="4176"/>
         <source>&amp;Raise</source>
-        <translation></translation>
+        <translation>&amp;Elevar</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="682"/>
         <source>New Node</source>
-        <translation></translation>
+        <translation>Nuevo nodo</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1092"/>
@@ -1210,92 +1212,93 @@
         <location filename="../../fn.cpp" line="4891"/>
         <location filename="../../fn.cpp" line="4917"/>
         <source>Untitled</source>
-        <translation></translation>
+        <translation>Sin título</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1862"/>
         <source>Deletion</source>
-        <translation></translation>
+        <translation>Borrado</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="1975"/>
         <source>Tag(s) for this node</source>
-        <translation></translation>
+        <translation>Etiqueta(s) para este nodo</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="2063"/>
         <location filename="../../fn.cpp" line="3241"/>
         <location filename="../../fn.cpp" line="3467"/>
         <source>Image Files (*.svg *.png *.jpg *.jpeg *.bmp *.gif);;All Files (*)</source>
-        <translation></translation>
+        <translation>Archivos de imagen (*.svg *.png *.jpg *.jpeg *.bmp *.gif);;Todos los archivos (*)</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3127"/>
         <location filename="../../fn.cpp" line="3287"/>
         <source>Scale to</source>
-        <translation></translation>
+        <translation>Escalar al</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3131"/>
         <location filename="../../fn.cpp" line="3290"/>
         <source>%</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3281"/>
         <source>Scale Image(s)</source>
-        <translation></translation>
+        <translation>Escalar imágenes</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3407"/>
         <source>untitled</source>
-        <translation></translation>
+        <translation>sin título</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3437"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;big&gt;Image cannot be saved! Retry?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;&lt;b&gt;&lt;big&gt;¡No se puede guradar la imagen! ¿Quiere reintentarlo?&lt;/big&gt;&lt;/b&gt;&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3438"/>
         <source>&lt;center&gt;Maybe you did not choose a proper extension&lt;/center&gt;
 &lt;center&gt;or do not have write permission.&lt;/center&gt;&lt;p&gt;&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;Puede que no eligiera una extensión adecuada&lt;/center&gt;
+&lt;center&gt;o que no tenga permisos de escritura.&lt;/center&gt;&lt;p&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3465"/>
         <source>Save Image As...</source>
-        <translation></translation>
+        <translation>Guardar imagen como...</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3517"/>
         <source>Insert Table</source>
-        <translation></translation>
+        <translation>Insertar tabla</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3523"/>
         <source>Rows:</source>
-        <translation></translation>
+        <translation>Filas:</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3529"/>
         <source>Columns:</source>
-        <translation></translation>
+        <translation>Columnas:</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3694"/>
         <source>Preferences</source>
-        <translation></translation>
+        <translation>Preferencias</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3702"/>
         <source>Window</source>
-        <translation></translation>
+        <translation>Ventana</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3706"/>
         <source>Remember window &amp;size</source>
-        <translation></translation>
+        <translation>Recordar el tamaño de la &amp;ventana</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3707"/>
@@ -1303,12 +1306,15 @@
 this dialog and also on exit.
 
 Uncheck to set a fixed size!</source>
-        <translation></translation>
+        <translation>Guarda el tamaño de la ventana al cerrar
+este diálogo y también al salir
+
+¡Desmárquelo para hacer el tamaño fijo!</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3711"/>
         <source>Start with this size: </source>
-        <translation></translation>
+        <translation>Empezar con este tamaño: </translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3721"/>
@@ -1316,12 +1322,12 @@ Uncheck to set a fixed size!</source>
         <location filename="../../fn.cpp" line="3779"/>
         <location filename="../../fn.cpp" line="3780"/>
         <source> px</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3725"/>
         <source>Remember &amp;tree width</source>
-        <translation></translation>
+        <translation>Recordar el &amp;ancho del árbol</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3726"/>
@@ -1329,12 +1335,14 @@ Uncheck to set a fixed size!</source>
 this dialog and also on exit.
 
 Uncheck for a width ratio of 170/530.</source>
-        <translation></translation>
+        <translation>Guarda el ancho del árbol al cerrar este diálogo y
+también al salir.
+Desmárquelo para un ratio de anchura de 170/530.</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3729"/>
         <source>Save &amp;position</source>
-        <translation></translation>
+        <translation>Guardar la &amp;posición</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3730"/>
@@ -1344,12 +1352,17 @@ this dialog and also on exit.
 (This may not work correctly
 under GTK+ DE&apos;s like Unity
 and Cinnamon.)</source>
-        <translation></translation>
+        <translation>Guarda la posición al cerrar
+este diálogo y también al salir.
+
+(Puede no funcionar correctamente
+en escritorios GTK+ como Unity
+y Cinnamon.)</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3735"/>
         <source>Add to s&amp;ystray</source>
-        <translation></translation>
+        <translation>Añadir a la bande&amp;ja del sistema</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3736"/>
@@ -1358,60 +1371,68 @@ If checked, the titlebar close button iconifies
 the window to the systray instead of quitting.
 
 Needs restarting of FeatherNotes to take effect.</source>
-        <translation></translation>
+        <translation>Decide si se usa un icono en la bandeja del sistema.
+Si se marca, el botón de cierre de la barra de título minimiza
+la ventana a la bandeja del sistema en vez de salir.
+
+Es necesario reiniciar FeatherNotes para que tenga efecto.</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3737"/>
         <source>Start i&amp;conified to tray</source>
-        <translation></translation>
+        <translation>Ini&amp;ciar minimizado en la bandeja</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3738"/>
         <source>The command line option --tray
 can be used instead of this.</source>
-        <translation></translation>
+        <translation>Se puede usar la opción de la línea
+de comandos --tray en vez de esto.</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3744"/>
         <source>Transparent t&amp;ree view</source>
-        <translation></translation>
+        <translation>Vista de árbol t&amp;ransparente</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3745"/>
         <source>Merge the tree view with its surroundings?</source>
-        <translation></translation>
+        <translation>¿Quiere fusionar la vista de árbol con lo que la rodea?</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3748"/>
         <source>Do not show t&amp;oolbar</source>
-        <translation></translation>
+        <translation>N&amp;o mostrar la barra de herramientas</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3750"/>
         <source>Do not show &amp;menubar</source>
-        <translation></translation>
+        <translation>No mostrar la barra de &amp;menús</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3751"/>
         <source>If the menubar is hidden,
 a menu button appears on the toolbar.</source>
-        <translation></translation>
+        <translation>Si la barra de menu está oculta,
+aparece un botón de menú en la barra
+de herramientas.</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3755"/>
         <source>Running &amp;under Enlightenment?</source>
-        <translation></translation>
+        <translation>¿Está &amp;usando Enlightenment?</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3756"/>
         <source>Check this under Enlightenment (or, probably, another DE)
 to use the systray icon more easily!</source>
-        <translation></translation>
+        <translation>¡Marque esto en Enlightenment (o, quizás, otro entorno de escritorio)
+para usar la bandeja del sistema con más facilidad!</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3757"/>
         <source>Shifts (X × Y): </source>
-        <translation></translation>
+        <translation>Desplazamientos (X × Y): </translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3758"/>
@@ -1423,168 +1444,180 @@ if it is on the left or right, the X-coordinate should be set.
 
 After choosing the coordinate shifts, put the window in a proper
 position and then restart FeatherNotes!</source>
-        <translation></translation>
+        <translation>Algunos entornos de escritorio (como Enlightenment) pueden no reportar
+la posición de la ventana correctamente. En ese caso, puede intentar arreglar
+el problema aquí.
+
+Si el panel está abajo o arriba, debe asignar un valor a la coordenada Y;
+si está a la izquierda o a la derecha, se lo debe asignar a la coordenada X.
+
+¡Después de elegir los desplazamientos de coordenadas, ponga la ventana en
+una posición adecuada y reinicie FeatherNotes!</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3871"/>
         <source>Text</source>
-        <translation></translation>
+        <translation>Texto</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3874"/>
         <source>&amp;Wrap lines by default</source>
-        <translation></translation>
+        <translation>&amp;Dividir las líneas por omisión</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3875"/>
         <source>Auto-&amp;indent by default</source>
-        <translation></translation>
+        <translation>Sangría automát&amp;ica por omisón</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3876"/>
         <source>Auto-&amp;bracket
 (Requires application restart)</source>
-        <translation></translation>
+        <translation>&amp;Paréntesis automáticos
+(Requiere reiniciar la aplicación)</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3877"/>
         <source>This covers parentheses, braces, brackets and quotes.
 
 Needs restarting of FeatherNotes to take effect.</source>
-        <translation></translation>
+        <translation>Esto incluye paréntesis, llaves, corchetes y comillas.
+
+Es necesario reiniciar FeatherNotes para que tenga effecto.</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3878"/>
         <source>&amp;Auto-save every</source>
-        <translation></translation>
+        <translation>&amp;Autoguardar cada</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3882"/>
         <source> minute(s)</source>
-        <translation></translation>
+        <translation> minuto(s)</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3887"/>
         <source>Workaround for &amp;Qt5&apos;s scroll jump bug</source>
-        <translation></translation>
+        <translation>Solución provisional para el fallo de saltos de desplazamiento de &amp;Qt5</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="3888"/>
         <source>This is not a complete fix but
 prevents annoying scroll jumps.</source>
-        <translation></translation>
+        <translation>No es una solución completa, pero previene
+los molestos saltos de desplazamiento.</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4642"/>
         <source>Print Document</source>
-        <translation></translation>
+        <translation>Imprimir el documento</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4698"/>
         <source>Export HTML</source>
-        <translation></translation>
+        <translation>Exportar a HTML</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4703"/>
         <source>Export:</source>
-        <translation></translation>
+        <translation>Exportar:</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4704"/>
         <source>&amp;Current node</source>
-        <translation></translation>
+        <translation>Nodo a&amp;ctual</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4706"/>
         <source>With all &amp;sub-nodes</source>
-        <translation></translation>
+        <translation>Con todos los &amp;subnodos</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4707"/>
         <source>&amp;All nodes</source>
-        <translation></translation>
+        <translation>Todos los &amp;nodos</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4719"/>
         <source>Output file:</source>
-        <translation></translation>
+        <translation>Archivo de salida:</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4738"/>
         <source>Select path</source>
-        <translation></translation>
+        <translation>Seleccionar la ruta</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4922"/>
         <source>Save HTML As...</source>
-        <translation></translation>
+        <translation>Guardar HTML como...</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4924"/>
         <source>HTML Files (*.html *.htm)</source>
-        <translation></translation>
+        <translation>Archivos HTML (*.html *.htm)</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4945"/>
         <source>Set Password</source>
-        <translation></translation>
+        <translation>Establecer la contraseña</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4953"/>
         <source>Type password</source>
-        <translation></translation>
+        <translation>Escriba la contraseña</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="4958"/>
         <source>Retype password</source>
-        <translation></translation>
+        <translation>Reescriba la contraseña</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5034"/>
         <source>&lt;center&gt;Passwords were different. Retry!&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;Las contraseñas son distintas. ¡Reinténtalo!&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5066"/>
         <location filename="../../fn.cpp" line="5074"/>
         <source>Enter Password</source>
-        <translation></translation>
+        <translation>Introduzca la contraseña</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5140"/>
         <source>&lt;center&gt;Wrong password. Retry!&lt;/center&gt;</source>
-        <translation></translation>
+        <translation>&lt;center&gt;Contraseña incorrecta. ¡Vuelva a intentarlo!&lt;/center&gt;</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5179"/>
         <source>A lightweight notes manager</source>
-        <translation></translation>
+        <translation>Un gestor de notas ligero</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5180"/>
         <source>based on Qt5</source>
-        <translation></translation>
+        <translation>basado en Qt5</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5181"/>
         <source>Author</source>
-        <translation></translation>
+        <translation>Autor</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5183"/>
         <location filename="../../fn.cpp" line="5184"/>
         <source>About FeatherNotes</source>
-        <translation></translation>
+        <translation>Acerca de FeatherNotes</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5183"/>
         <source>Translators</source>
-        <translation></translation>
+        <translation>Traductores</translation>
     </message>
     <message>
         <location filename="../../fn.cpp" line="5182"/>
         <source>aka.</source>
-        <translation></translation>
+        <translation>alias.</translation>
     </message>
 </context>
 <context>
@@ -1592,13 +1625,13 @@ prevents annoying scroll jumps.</source>
     <message>
         <location filename="../../lineedit.cpp" line="35"/>
         <source>Clear text (Ctrl+K)</source>
-        <translation></translation>
+        <translation>Limpiar el texto (Ctrl+K)</translation>
     </message>
     <message>
         <location filename="../../lineedit.cpp" line="81"/>
         <source>Ctrl+K</source>
         <comment>Clear text</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1606,7 +1639,7 @@ prevents annoying scroll jumps.</source>
     <message>
         <location filename="../../helpDialog.ui" line="14"/>
         <source>Help</source>
-        <translation></translation>
+        <translation>Ayuda</translation>
     </message>
 </context>
 <context>
@@ -1615,7 +1648,7 @@ prevents annoying scroll jumps.</source>
         <location filename="../../domitem.cpp" line="100"/>
         <location filename="../../domitem.cpp" line="137"/>
         <source>New Node</source>
-        <translation></translation>
+        <translation>Nuevo nodo</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Hi.

There was something wrong with the translation file. It was completely untranslated but it did lack the  `type="unfinished"` attribute. I think that it happens the same with `feathernotes_cy.ts`.

Greetings.

