### PR TITLE
fix build error

### DIFF
--- a/feathernotes/fn.cpp
+++ b/feathernotes/fn.cpp
@@ -35,6 +35,7 @@
 #include <QStandardPaths>
 #endif
 
+#include <QDateTime>
 #include <QDir>
 #include <QTextStream>
 #include <QToolButton>


### PR DESCRIPTION
When attempting to build I would get this error:
`incomplete type ‘QDateTime’ used in nested name specifier`