### PR TITLE
Automatically open the last notes file (see issue #7)

### DIFF
--- a/feathernotes/fn.h
+++ b/feathernotes/fn.h
@@ -94,7 +94,7 @@ public:
         position_ = pos;
     }
 
-    bool startWhereLeftOff(bool startWhereLeftOff) {
+    void startWhereLeftOff(bool startWhereLeftOff) {
         startWhereLeftOff_ = startWhereLeftOff;
     }
     bool isStartWhereLeftOff() {

--- a/feathernotes/fn.h
+++ b/feathernotes/fn.h
@@ -94,6 +94,13 @@ public:
         position_ = pos;
     }
 
+    bool startWhereLeftOff(bool startWhereLeftOff) {
+        startWhereLeftOff_ = startWhereLeftOff;
+    }
+    bool isStartWhereLeftOff() {
+        return startWhereLeftOff_;
+    }
+
     bool isUnderE() const {
         return underE_;
     }
@@ -342,6 +349,7 @@ private:
     void setTitle (const QString& fname);
     void notSaved();
     void setNodesTexts();
+    void setStartWhereLeftOffFile(const QString &leftOffFile = "");
     bool unSaved (bool modified);
     TextEdit *newWidget();
     void mergeFormatOnWordOrSelection (const QTextCharFormat &format);
@@ -397,6 +405,7 @@ private:
     bool shownBefore_,
          remSize_, remSplitter_,
          remPosition_,
+         startWhereLeftOff_,
          hasTray_,
          minToTray_,
          wrapByDefault_,

--- a/feathernotes/predDialog.ui
+++ b/feathernotes/predDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>386</height>
+    <height>501</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -116,6 +116,13 @@ and Cinnamon.)</string>
             </property>
             <property name="text">
              <string>Save &amp;position</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="startWhereLeftOff">
+            <property name="text">
+             <string>Start where &amp;left off</string>
             </property>
            </widget>
           </item>

--- a/feathernotes/pref.cpp
+++ b/feathernotes/pref.cpp
@@ -168,6 +168,12 @@ PrefDialog::PrefDialog (QWidget *parent)
             }
         });
 
+        /* start where left off */
+        ui->startWhereLeftOff->setChecked(win->isStartWhereLeftOff());
+        connect (ui->startWhereLeftOff, &QCheckBox::stateChanged, win, [this, win] (int checked) {
+            win->startWhereLeftOff(checked == Qt::Checked);
+        });
+
         /* use tray */
         ui->hasTrayBox->setChecked (win->hasTray());
         hasTray_ = win->hasTray();


### PR DESCRIPTION
This adds two new keys "startWhereLeftOff" and "startWhereLeftOffFile" to the applications-settings. The "startWhereLeftOff" setting is written when clicking the new checkbox "startWhereLeftOff" in the window-settings. The second setting-option is written when opening or saving a fn-note-db and read on start of the application if no file-argument was passed to the application on commandline.