### PR TITLE
Fixed tables being added with invisible borders

### DIFF
--- a/feathernotes/fn.cpp
+++ b/feathernotes/fn.cpp
@@ -4868,6 +4868,8 @@ void FN::addTable()
             QTextCursor cur = textEdit->textCursor();
             QTextTableFormat tf;
             tf.setCellPadding (3);
+            tf.setCellSpacing (2);
+            tf.setBorderCollapse (false);
             QTextTable *table = cur.insertTable (rows, columns);
             table->setFormat (tf);
         }


### PR DESCRIPTION
This has been a regression (with Qt 6.8) for quite some time.

| Before | After |
|----|----|
| ![image](https://github.com/user-attachments/assets/99d1d9be-5e1b-42aa-b035-9ab8b6e419e7) | ![image](https://github.com/user-attachments/assets/a50c721a-32cf-44af-b375-845bf91459db)
