### PR TITLE
Allow disabling SimpleCrypt at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,4 +22,6 @@ if (OS2)
   option(WITHOUT_X11 "Compiling without X11..." ON)
 endif()
 
+option(WITH_SIMPLECRYPT "Enable SimpleCrypt-based file encryption support" ON)
+
 add_subdirectory(feathernotes)

--- a/feathernotes/CMakeLists.txt
+++ b/feathernotes/CMakeLists.txt
@@ -69,10 +69,14 @@ set(feathernotes_SRCS
     lineedit.cpp
     pref.cpp
     textedit.cpp
-    simplecrypt.cpp
     vscrollbar.cpp
     printing.cpp
     svgicons.cpp)
+
+if(WITH_SIMPLECRYPT)
+  list(APPEND feathernotes_SRCS simplecrypt.cpp)
+  add_definitions(-DHAS_SIMPLECRYPT)
+endif()
 
 if(WITH_HUNSPELL)
   set(feathernotes_SRCS ${feathernotes_SRCS} spellChecker.cpp spellDialog.cpp)


### PR DESCRIPTION
While packaging this application for Fedora, this dependency's license was brought to my attention. Given that the password protection feature is really more of an obfuscation feature than a full-fledged encryption feature, I felt it would be prudent to disable the feature in Fedora to avoid confusing users who might be expecting stronger encryption and might not have read the documentation. This PR adds a compile-time option to disable SimpleCrypt. SimpleCrypt is enabled by default for backward compatibility. When SimpleCrypt is disabled using the new option, we don't allow the creation of new obfuscated documents and fail gracefully with an error message when an existing obfuscated document is opened. I suggest reviewing this PR with the **Hide Whitespace** option enabled.