### PR TITLE
Handle empty lines in spellchecker files

### DIFF
--- a/feathernotes/spellChecker.cpp
+++ b/feathernotes/spellChecker.cpp
@@ -43,7 +43,8 @@ SpellChecker::SpellChecker (const QString& dictionaryPath, const QString& userDi
         QTextStream stream (&_affixFile);
         QRegularExpression encDetector ("^\\s*SET\\s+([A-Z0-9\\-]+)\\s*", QRegularExpression::CaseInsensitiveOption);
         QRegularExpressionMatch match;
-        for (QString line = stream.readLine(); !line.isEmpty(); line = stream.readLine())
+        QString line;
+        while (stream.readLineInto (&line))
         {
             if (line.indexOf (encDetector, 0, &match) > -1)
             {
@@ -67,8 +68,12 @@ SpellChecker::SpellChecker (const QString& dictionaryPath, const QString& userDi
         if (userDictonaryFile.open (QIODevice::ReadOnly))
         {
             QTextStream stream (&userDictonaryFile);
-            for (QString word = stream.readLine(); !word.isEmpty(); word = stream.readLine())
-                ignoreWord (word);
+            QString word;
+            while (stream.readLineInto (&word))
+            {
+                if (!word.isEmpty())
+                    ignoreWord (word);
+            }
             userDictonaryFile.close();
         }
     }


### PR DESCRIPTION
This is the same fix as in FeatherPad:
https://github.com/tsujan/FeatherPad/pull/921