### PR TITLE
Escape node names in exported HTML headings

### DIFF
--- a/feathernotes/fn.cpp
+++ b/feathernotes/fn.cpp
@@ -6058,6 +6058,8 @@ QString FN::nodeAddress (QModelIndex index)
         indx = model_->parent (indx);
     }
     bool rtl = l.join (" ").isRightToLeft();
+    for (QString &str : l)
+        str = str.toHtmlEscaped();
     if (rtl)
         res = l.join (" ← ");
     else


### PR DESCRIPTION
Node names are inserted into generated HTML headings when exporting or printing multiple nodes. They need to be HTML-escaped before being embedded in that markup.

Without escaping, a node named `A < B & C` is exported with a broken heading.